### PR TITLE
Identify pin1 on connectors MP1, MP2, MP3

### DIFF
--- a/PowerDistribution/MegaShield.brd
+++ b/PowerDistribution/MegaShield.brd
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE eagle SYSTEM "eagle.dtd">
-<eagle version="7.6.0">
+<eagle version="7.7.0">
 <drawing>
 <settings>
 <setting alwaysvectorfont="yes"/>
 <setting verticaltext="up"/>
 </settings>
-<grid distance="0.000123031496" unitdist="mil" unit="mil" style="lines" multiple="1" display="yes" altdistance="5" altunitdist="mil" altunit="mil"/>
+<grid distance="0.05" unitdist="inch" unit="inch" style="lines" multiple="1" display="yes" altdistance="5" altunitdist="mil" altunit="inch"/>
 <layers>
 <layer number="1" name="Top" color="12" fill="1" visible="yes" active="yes"/>
 <layer number="2" name="Route2" color="1" fill="3" visible="no" active="no"/>
@@ -4546,6 +4546,9 @@
 <text x="5.182665625" y="38.503584375" size="2.54" layer="21" ratio="20">MP1</text>
 <text x="43.734540625" y="40.5377125" size="2.54" layer="21" ratio="20">MP2</text>
 <text x="50.699290625" y="40.640221875" size="2.54" layer="21" ratio="20">MP3</text>
+<text x="6.35" y="35.56" size="1.778" layer="21">1</text>
+<text x="44.45" y="35.56" size="1.778" layer="21">1</text>
+<text x="51.308" y="35.56" size="1.778" layer="21">1</text>
 </plain>
 <libraries>
 <library name="pinhead">
@@ -5124,15 +5127,15 @@ design rules under a new name.</description>
 <attribute name="VALUE" x="14.605" y="-0.635" size="1.27" layer="27"/>
 </element>
 <element name="USB" library="eagle-ltspice" package="LED_1206" value="" x="7.133590625" y="50.53169375" smashed="yes" rot="R180">
+<attribute name="NAME" x="4.538896875" y="48.1784875" size="1.27" layer="25" rot="SR90"/>
+<attribute name="SPICEMODEL" value="NONE" x="7.133590625" y="50.53169375" size="1.778" layer="27" rot="R180" display="off"/>
 <attribute name="SPICEPREFIX" value="D" x="7.133590625" y="50.53169375" size="1.778" layer="27" rot="R180" display="off"/>
 <attribute name="SPICETYPE" value="diode" x="7.133590625" y="50.53169375" size="1.778" layer="27" rot="R180" display="off"/>
-<attribute name="SPICEMODEL" value="NONE" x="7.133590625" y="50.53169375" size="1.778" layer="27" rot="R180" display="off"/>
-<attribute name="NAME" x="4.538896875" y="48.1784875" size="1.27" layer="25" rot="SR90"/>
 <attribute name="VALUE" x="8.403590625" y="53.07169375" size="1.27" layer="27" rot="R180"/>
 </element>
 <element name="R1" library="eagle-ltspice" package="R0805" value="270" x="11.721359375" y="50.594009375" smashed="yes">
-<attribute name="SPICEPREFIX" value="R" x="11.721359375" y="50.594009375" size="1.778" layer="27" display="off"/>
 <attribute name="SPICEMODEL" value="NONE" x="11.721359375" y="50.594009375" size="1.778" layer="27" display="off"/>
+<attribute name="SPICEPREFIX" value="R" x="11.721359375" y="50.594009375" size="1.778" layer="27" display="off"/>
 <attribute name="VALUE" x="14.169025" y="49.942646875" size="1.27" layer="27"/>
 </element>
 <element name="IC1" library="st-microelectronics" package="POWERSO-20" value="L298SO" x="28.125865625" y="28.83225" smashed="yes" rot="R270"/>
@@ -5154,10 +5157,10 @@ design rules under a new name.</description>
 <element name="U$9" library="MakesmithDiode" package="SMA" value="MRA4004" x="38.152209375" y="36.14745" smashed="yes" rot="R270"/>
 <element name="U$10" library="MakesmithDiode" package="SMA" value="MRA4004" x="42.11571875" y="36.14745" smashed="yes" rot="R90"/>
 <element name="J1" library="con-jack" package="DCJ0202" value="DCJ0202" x="89.263790625" y="6.410875" smashed="yes" rot="R90">
-<attribute name="OC_NEWARK" value="unknown" x="89.263790625" y="6.410875" size="1.778" layer="27" rot="R90" display="off"/>
 <attribute name="MF" value="" x="89.263790625" y="6.410875" size="1.778" layer="27" rot="R90" display="off"/>
-<attribute name="OC_FARNELL" value="unknown" x="89.263790625" y="6.410875" size="1.778" layer="27" rot="R90" display="off"/>
 <attribute name="MPN" value="" x="89.263790625" y="6.410875" size="1.778" layer="27" rot="R90" display="off"/>
+<attribute name="OC_FARNELL" value="unknown" x="89.263790625" y="6.410875" size="1.778" layer="27" rot="R90" display="off"/>
+<attribute name="OC_NEWARK" value="unknown" x="89.263790625" y="6.410875" size="1.778" layer="27" rot="R90" display="off"/>
 </element>
 <element name="U$1" library="JST-CON" package="JST-PHR-6-SMD" value="JST-PH-6" x="8.96595625" y="36.52845" smashed="yes" rot="R270"/>
 <element name="U$12" library="JST-CON" package="JST-PHR-6-SMD" value="JST-PH-6" x="47.202609375" y="36.52845" rot="R270"/>
@@ -5176,13 +5179,13 @@ design rules under a new name.</description>
 <element name="IC2" library="st-microelectronics" package="POWERSO-20" value="L298SO" x="73.802409375" y="28.83225" smashed="yes" rot="R270"/>
 <element name="U$2" library="MakesmithDiode" package="SMA" value="MRA4004" x="59.766634375" y="36.14745" smashed="yes" rot="R270"/>
 <element name="C3" library="eagle-ltspice" package="C0805" value=".1uF" x="77.042059375" y="38.02705" smashed="yes" rot="R180">
-<attribute name="SPICEPREFIX" value="C" x="86.159184375" y="30.32571875" size="1.778" layer="27" rot="R180" display="off"/>
 <attribute name="SPICEMODEL" value="NONE" x="86.159184375" y="30.32571875" size="1.778" layer="27" rot="R180" display="off"/>
+<attribute name="SPICEPREFIX" value="C" x="86.159184375" y="30.32571875" size="1.778" layer="27" rot="R180" display="off"/>
 <attribute name="VALUE" x="75.27083125" y="40.648959375" size="1.27" layer="27" rot="R180"/>
 </element>
 <element name="C4" library="eagle-ltspice" package="C0805" value=".1uF" x="72.89439375" y="38.0023625" smashed="yes">
-<attribute name="SPICEPREFIX" value="C" x="58.532640625" y="39.6923625" size="1.778" layer="27" display="off"/>
 <attribute name="SPICEMODEL" value="NONE" x="58.532640625" y="39.6923625" size="1.778" layer="27" display="off"/>
+<attribute name="SPICEPREFIX" value="C" x="58.532640625" y="39.6923625" size="1.778" layer="27" display="off"/>
 </element>
 <element name="U$11" library="MakesmithDiode" package="SMA" value="MRA4004" x="63.747534375" y="36.14745" smashed="yes" rot="R90"/>
 <element name="U$13" library="MakesmithDiode" package="SMA" value="MRA4004" x="59.525384375" y="26.69865" smashed="yes" rot="R90"/>
@@ -5204,15 +5207,15 @@ design rules under a new name.</description>
 <attribute name="VALUE" x="2.542575" y="46.98901875" size="1.27" layer="27" rot="R270"/>
 </element>
 <element name="R2" library="eagle-ltspice" package="R0805" value="330" x="86.01535" y="13.932378125" smashed="yes" rot="R180">
-<attribute name="SPICEPREFIX" value="R" x="86.01535" y="13.932378125" size="1.778" layer="27" rot="R180" display="off"/>
-<attribute name="SPICEMODEL" value="NONE" x="86.01535" y="13.932378125" size="1.778" layer="27" rot="R180" display="off"/>
 <attribute name="NAME" x="86.65035" y="12.662378125" size="1.27" layer="25" rot="R180"/>
+<attribute name="SPICEMODEL" value="NONE" x="86.01535" y="13.932378125" size="1.778" layer="27" rot="R180" display="off"/>
+<attribute name="SPICEPREFIX" value="R" x="86.01535" y="13.932378125" size="1.778" layer="27" rot="R180" display="off"/>
 <attribute name="VALUE" x="82.38166875" y="15.00325625" size="1.27" layer="27" rot="R270"/>
 </element>
 <element name="12VPOWER" library="eagle-ltspice" package="LED_1206" value="" x="91.180903125" y="13.94774375" smashed="yes">
+<attribute name="SPICEMODEL" value="NONE" x="91.180903125" y="13.94774375" size="1.778" layer="27" display="off"/>
 <attribute name="SPICEPREFIX" value="D" x="91.180903125" y="13.94774375" size="1.778" layer="27" display="off"/>
 <attribute name="SPICETYPE" value="diode" x="91.180903125" y="13.94774375" size="1.778" layer="27" display="off"/>
-<attribute name="SPICEMODEL" value="NONE" x="91.180903125" y="13.94774375" size="1.778" layer="27" display="off"/>
 <attribute name="VALUE" x="89.910903125" y="11.40774375" size="1.27" layer="27"/>
 </element>
 </elements>


### PR DESCRIPTION
Several users had trouble identifying pin1 for the motor connectors. The board is congested in that area, the pin1 text winds up beneath the connector.